### PR TITLE
Add upsert support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 It adds:
 * `getById`
 * `insert`
+* `upsert`
 * `updateById`
 * `updateWhere`
 * `replaceById`
@@ -123,12 +124,27 @@ Adds document to collection, sets an id and returns created document.
 var post = _.insert(db.posts, {body: 'New post'});
 ```
 
-If the document has already an id, it will be used to insert or replace.
+If the document already has an id, and it is the same as an existing document in the collection, an error is thrown.
 
 ```javascript
 _.insert(db.posts, {id: 1, body: 'New post'});
-_.insert(db.posts, {id: 1, title: 'New title'});
-_.getById(db.posts, 1) // {id: 1, title: 'New title'}
+_.insert(db.posts, {id: 1, title: 'New title'}); // Throws an error
+```
+
+__upsert(collection, document)__
+
+Adds document to collection, sets an id and returns created document.
+
+```javascript
+var post = _.upsert(db.posts, {body: 'New post'});
+```
+
+If the document already has an id, it will be used to insert or replace.
+
+```javascript
+_.upsert(db.posts, {id: 1, body: 'New post'});
+_.upsert(db.posts, {id: 1, title: 'New title'});
+_.getById(db.posts, 1); // {id: 1, title: 'New title'}
 ```
 
 __updateById(collection, id, attrs)__

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,14 @@ module.exports = {
     return uuid();
   },
 
+  insert: function(collection, doc) {
+    doc[this.__id()] = doc[this.__id()] || this.createId(collection, doc);
+    var d = this.getById(collection, doc[this.__id()]);
+    if (d) throw new Error("Insert failed; duplicate id.");
+    collection.push(doc);
+    return doc;
+  },
+
   upsert: function(collection, doc) {
     if (doc[this.__id()]) {
       // id is set

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ module.exports = {
     return uuid();
   },
 
-  insert: function(collection, doc) {
+  upsert: function(collection, doc) {
     if (doc[this.__id()]) {
       // id is set
       var d = this.getById(collection, doc[this.__id()]);

--- a/test/test.js
+++ b/test/test.js
@@ -67,16 +67,50 @@ Object.keys(libs).forEach(function(name) {
     describe('insert', function() {
       describe('and id is set', function() {
         it('inserts and returns inserted doc', function() {
-          var doc = _.insert(db.posts, {id: 'foo', body: 'one' });
+          var doc = _.insert(db.posts, {id: 'foo', body: 'one'});
+
+          assert.equal(db.posts.length, 4);
+          assert.deepEqual(doc, {id: 'foo', body: 'one'});
+          assert.deepEqual(_.getById(db.posts, doc.id), {id: 'foo', body: 'one'});
+        });
+
+        it('does not replace in place and throws an error', function() {
+          var length = db.posts.length;
+
+          assert.throws(function() {
+            _.insert(db.posts, {id: 2, title: 'one'});
+          }, /duplicate/);
+          assert.equal(db.posts.length, length);
+          assert.deepEqual(_.getById(db.posts, 2), {id: 2, body: 'two', published: false});
+          assert.deepEqual(_.map(db.posts, 'id'), [1, 2, 3]);
+        });
+      });
+
+      describe('and id is not set', function() {
+        it('inserts, sets an id and returns inserted doc', function() {
+          var doc = _.insert(db.posts, {body: 'one'});
+
+          assert.equal(db.posts.length, 4);
+          assert(doc.id);
+          assert.equal(doc.body, 'one');
+        });
+      });
+    });
+
+    describe('upsert', function() {
+      describe('and id is set', function() {
+        it('inserts and returns inserted doc', function() {
+          var doc = _.upsert(db.posts, {id: 'foo', body: 'one'});
 
           assert.equal(db.posts.length, 4);
           assert.deepEqual(doc, {id: 'foo', body: 'one' });
-          assert.deepEqual(_.getById(db.posts, doc.id), {id: 'foo', body: 'one' });
+          assert.deepEqual(_.getById(db.posts, doc.id), {id: 'foo', body: 'one'});
         });
 
         it('replaces in place and returns inserted doc', function() {
-          var length = db.posts.length;
-          doc = _.insert(db.posts, {id: 2, title: 'one'});
+          var length = db.posts.length,
+              doc = _.upsert(db.posts, {id: 2, title: 'one'});
+
           assert.equal(db.posts.length, length);
           assert.deepEqual(doc, {id: 2, title: 'one'});
           assert.deepEqual(_.getById(db.posts, doc.id), {id: 2, title: 'one'});
@@ -86,7 +120,7 @@ Object.keys(libs).forEach(function(name) {
 
       describe('and id is not set', function() {
         it('inserts, sets an id and returns inserted doc', function() {
-          var doc = _.insert(db.posts, {body: 'one' });
+          var doc = _.upsert(db.posts, {body: 'one'});
 
           assert.equal(db.posts.length, 4);
           assert(doc.id);


### PR DESCRIPTION
Renames the current `insert` to `upsert`, and introduces a new `insert` that throws an error for duplicates (instead of performing a replace).

Resolves #10.